### PR TITLE
debug : kaplan-meier curve 원점 근처 곡선 소실

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,14 +1,16 @@
 Package: jskm
 Title: Kaplan-Meier Plot with 'ggplot2'
-Version: 0.6.0
-Date: 2026-01-27
+Version: 0.6.1
+Date: 2026-02-11
 Authors@R: c(person("Jinseob", "Kim", email = "jinseob2kim@gmail.com", role = c("aut", "cre"),  comment = c(ORCID = "0000-0002-9403-605X")),
              person("yoonkyoung", "Chun", email = "rachel200357@gmail.com", role = "aut"),
              person("Zarathu", role = c("cph", "fnd")),
              person("sungho", "Choi", email = "1213sam0@gmail.com", role = "aut"),
              person("Mingu", "Jee", email = "rafamingujee047@gmail.com", role = "aut"),
              person("Wonbin", "Hahn", email = "andrewhahn2001@gmail.com", role = "aut"),
-             person("Taehong", "Kim", role = "aut", email = "widestar8848@gmail.com")
+             person("Taehong", "Kim", role = "aut", email = "widestar8848@gmail.com"),
+             person("Sangho", "Oh", role = "aut", email = "godqhrosangho01@gmail.com"),
+             person("Sewon", "Lee", role = "aut", email = "leesewon214@gmail.com")
              )
 Description: The function 'jskm()' creates publication quality Kaplan-Meier plot with at risk tables below. 'svyjskm()' provides plot for weighted Kaplan-Meier estimator. 
 Depends: R (>= 3.4.0)

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,8 @@
+# jskm 0.6.1
+* Fix : `svyjskm` kaplan-meier curve is vanished at starting point (0,0)
+
+* Fix : `jskm` kaplan-meier curve is vanished at starting point (0,0)
+
 # jskm 0.6.0
 
 * Update: Improve UI consistency (linewidth, axis alignment, risk table style) for `jskm` and `svyjskm`.

--- a/R/jskm.R
+++ b/R/jskm.R
@@ -457,19 +457,19 @@ jskm <- function(sfit,
       axis.line.x = element_line(linewidth = 0.5, linetype = "solid", colour = "black"),
       axis.line.y = element_line(linewidth = 0.5, linetype = "solid", colour = "black")
     ) +
-    scale_x_continuous(xlabs, breaks = times, limits = xlims, expand = c(0, 0))
+    scale_x_continuous(xlabs, breaks = times, limits = xlims, expand = expansion(mult = c(0.001, 0.001)))
     
   if (!is.null(surv.by)) {
     p <- p + scale_y_continuous(ylabs, 
                                 limits = ylims, 
                                 labels = scale_labels, 
                                 breaks = seq(ylims[1], ylims[2], by = surv.by),
-                                expand = c(0, 0)) # 여백 제거 추가
+                                expand = expansion(mult = c(0.001, 0.001))) 
   } else {
     p <- p + scale_y_continuous(ylabs, 
                                 limits = ylims, 
                                 labels = scale_labels,
-                                expand = c(0, 0)) # 여백 제거 추가
+                                expand = expansion(mult = c(0.001, 0.001))) 
   }
   
   

--- a/R/svyjskm.R
+++ b/R/svyjskm.R
@@ -484,24 +484,24 @@ svyjskm <- function(sfit,
       legend.key = element_rect(colour = NA),
       panel.border = element_blank()
     ) +
-    # [수정] x축 0점 딱 붙이기
-    scale_x_continuous(xlabs, breaks = times, limits = xlims, expand = c(0, 0))
+    # [수정] x축 여백 변경
+    scale_x_continuous(xlabs, breaks = times, limits = xlims, expand = expansion(mult = c(0.005, 0.005)))
 
   # y축 설정 부분
   if (!is.null(surv.by)) {
     p <- p + scale_y_continuous(
-      name = ylabs,                  # 명시적으로 ylabs 변수 사용
+      name = ylabs,                  
       limits = ylims, 
       labels = scale_labels, 
       breaks = seq(ylims[1], ylims[2], by = surv.by),
-      expand = c(0, 0)               # 0점 밀착
+      expand = expansion(mult = c(0.005, 0.005)) # 상하 여백 변경
     )
   } else {
     p <- p + scale_y_continuous(
-      name = ylabs,                  # 명시적으로 ylabs 변수 사용
+      name = ylabs,                  
       limits = ylims, 
       labels = scale_labels,
-      expand = c(0, 0)               # 0점 밀착
+      expand = expansion(mult = c(0.005, 0.005)) # 상하 여백 변경
     )
   }
 

--- a/R/svyjskm.R
+++ b/R/svyjskm.R
@@ -485,7 +485,7 @@ svyjskm <- function(sfit,
       panel.border = element_blank()
     ) +
     # [수정] x축 여백 변경
-    scale_x_continuous(xlabs, breaks = times, limits = xlims, expand = expansion(mult = c(0.005, 0.005)))
+    scale_x_continuous(xlabs, breaks = times, limits = xlims, expand = expansion(mult = c(0.001, 0.001)))
 
   # y축 설정 부분
   if (!is.null(surv.by)) {
@@ -494,14 +494,14 @@ svyjskm <- function(sfit,
       limits = ylims, 
       labels = scale_labels, 
       breaks = seq(ylims[1], ylims[2], by = surv.by),
-      expand = expansion(mult = c(0.005, 0.005)) # 상하 여백 변경
+      expand = expansion(mult = c(0.001, 0.001)) # 상하 여백 변경
     )
   } else {
     p <- p + scale_y_continuous(
       name = ylabs,                  
       limits = ylims, 
       labels = scale_labels,
-      expand = expansion(mult = c(0.005, 0.005)) # 상하 여백 변경
+      expand = expansion(mult = c(0.001, 0.001)) # 상하 여백 변경
     )
   }
 

--- a/README.Rmd
+++ b/README.Rmd
@@ -21,7 +21,17 @@ Kaplan-Meier Plot with 'ggplot2': 'survfit' and 'svykm' objects from 'survival' 
 
 ```{r setup, include=FALSE}
 knitr::opts_chunk$set(echo = TRUE, message = F, warning = F, fig.path = "man/figures/README-")
-library(jskm)
+# library(jskm)
+library(ggplot2)
+library(survival)
+library(ggpubr)
+library(survey)
+library(patchwork)
+library(cmprsk)
+library(ggsci)
+source("R/jskm.R")
+source("R/svyjskm.R")
+source("R/adjustedLR.R")
 ```
 
 
@@ -57,14 +67,14 @@ jskm(fit,
 
 ### Cumulative hazard: 1- Survival probability
 ```{r}
-jskm(fit, ci = T, cumhaz = T, mark = F, ylab = "Cumulative incidence (%)", surv.scale = "percent", pval = T, pval.size = 6, pval.coord = c(300, 0.7))
+jskm(fit, ci = T, cumhaz = T, marks = F, surv.scale = "percent", pval = T, pval.size = 6, pval.coord = c(300, 0.7))
 ```
 
 ### Landmark analysis 
 
 ```{r}
-jskm(fit, mark = F, surv.scale = "percent", pval = T, table = T, cut.landmark = 500)
-jskm(fit, mark = F, surv.scale = "percent", pval = T, table = T, cut.landmark = 500, showpercent = T)
+jskm(fit, marks = F, surv.scale = "percent", pval = T, table = T, cut.landmark = 500)
+jskm(fit, marks = F, surv.scale = "percent", pval = T, table = T, cut.landmark = 500, showpercent = T)
 ```
 
 ### Competing risk analysis
@@ -76,8 +86,8 @@ colon$status2 <- colon$status
 colon$status2[1:400] <- 2
 colon$status2 <- factor(colon$status2)
 fit2 <- survfit(Surv(time, status2) ~ rx, data = colon)
-jskm(fit2, mark = F, surv.scale = "percent", table = T, status.cmprsk = "1")
-jskm(fit2, mark = F, surv.scale = "percent", table = T, status.cmprsk = "1", showpercent = T, cut.landmark = 500)
+jskm(fit2, marks = F, surv.scale = "percent", table = T, status.cmprsk = "1")
+jskm(fit2, marks = F, surv.scale = "percent", table = T, status.cmprsk = "1", showpercent = T, cut.landmark = 500)
 ```
 
 ### Theme 
@@ -85,13 +95,13 @@ jskm(fit2, mark = F, surv.scale = "percent", table = T, status.cmprsk = "1", sho
 #### JAMA
 
 ```{r}
-jskm(fit, theme = "jama", cumhaz = T, table = T, mark = F, ylab = "Cumulative incidence (%)", surv.scale = "percent", pval = T, pval.size = 6, pval.coord = c(300, 0.7))
+jskm(fit, theme = "jama", cumhaz = T, table = T, marks = F, surv.scale = "percent", pval = T, pval.size = 6, pval.coord = c(300, 0.7))
 ```
 
 #### NEJM
 
 ```{r}
-jskm(fit, theme = "nejm", nejm.infigure.ratiow = 0.7, nejm.infigure.ratioh = 0.4, nejm.infigure.ylim = c(0, 0.7), cumhaz = T, table = T, mark = F, ylab = "Cumulative incidence (%)", surv.scale = "percent", pval = T, pval.size = 6, pval.coord = c(300, 0.7))
+jskm(fit, theme = "nejm", nejm.infigure.ratiow = 0.7, nejm.infigure.ratioh = 0.4, nejm.infigure.ylim = c(0, 0.7), cumhaz = T, table = T, marks = F, surv.scale = "percent", pval = T, pval.size = 6, pval.coord = c(300, 0.7))
 ```
 
 ### Weighted Kaplan-Meier plot - `svykm.object` in **survey** package
@@ -110,7 +120,7 @@ s2 <- svykm(Surv(time, status > 0) ~ sex, design = dpbc)
 
 svyjskm(s1)
 svyjskm(s2, pval = T, table = T, design = dpbc)
-svyjskm(s2, cumhaz = T, ylab = "Cumulative incidence (%)", surv.scale = "percent", pval = T, design = dpbc, pval.coord = c(300, 0.7), showpercent = T)
+svyjskm(s2, cumhaz = T, surv.scale = "percent", pval = T, design = dpbc, pval.coord = c(300, 0.7), showpercent = T)
 ```
 
 If you want to get **confidence interval**, you should apply `se = T` option to `svykm` object.

--- a/README.md
+++ b/README.md
@@ -62,7 +62,7 @@ jskm(fit,
 ### Cumulative hazard: 1- Survival probability
 
 ``` r
-jskm(fit, ci = T, cumhaz = T, mark = F, ylab = "Cumulative incidence (%)", surv.scale = "percent", pval = T, pval.size = 6, pval.coord = c(300, 0.7))
+jskm(fit, ci = T, cumhaz = T, marks = F, surv.scale = "percent", pval = T, pval.size = 6, pval.coord = c(300, 0.7))
 ```
 
 ![](man/figures/README-unnamed-chunk-2-1.png)<!-- -->
@@ -70,13 +70,13 @@ jskm(fit, ci = T, cumhaz = T, mark = F, ylab = "Cumulative incidence (%)", surv.
 ### Landmark analysis
 
 ``` r
-jskm(fit, mark = F, surv.scale = "percent", pval = T, table = T, cut.landmark = 500)
+jskm(fit, marks = F, surv.scale = "percent", pval = T, table = T, cut.landmark = 500)
 ```
 
 ![](man/figures/README-unnamed-chunk-3-1.png)<!-- -->
 
 ``` r
-jskm(fit, mark = F, surv.scale = "percent", pval = T, table = T, cut.landmark = 500, showpercent = T)
+jskm(fit, marks = F, surv.scale = "percent", pval = T, table = T, cut.landmark = 500, showpercent = T)
 ```
 
 ![](man/figures/README-unnamed-chunk-3-2.png)<!-- -->
@@ -91,13 +91,13 @@ colon$status2 <- colon$status
 colon$status2[1:400] <- 2
 colon$status2 <- factor(colon$status2)
 fit2 <- survfit(Surv(time, status2) ~ rx, data = colon)
-jskm(fit2, mark = F, surv.scale = "percent", table = T, status.cmprsk = "1")
+jskm(fit2, marks = F, surv.scale = "percent", table = T, status.cmprsk = "1")
 ```
 
 ![](man/figures/README-unnamed-chunk-4-1.png)<!-- -->
 
 ``` r
-jskm(fit2, mark = F, surv.scale = "percent", table = T, status.cmprsk = "1", showpercent = T, cut.landmark = 500)
+jskm(fit2, marks = F, surv.scale = "percent", table = T, status.cmprsk = "1", showpercent = T, cut.landmark = 500)
 ```
 
 ![](man/figures/README-unnamed-chunk-4-2.png)<!-- -->
@@ -107,7 +107,7 @@ jskm(fit2, mark = F, surv.scale = "percent", table = T, status.cmprsk = "1", sho
 #### JAMA
 
 ``` r
-jskm(fit, theme = "jama", cumhaz = T, table = T, mark = F, ylab = "Cumulative incidence (%)", surv.scale = "percent", pval = T, pval.size = 6, pval.coord = c(300, 0.7))
+jskm(fit, theme = "jama", cumhaz = T, table = T, marks = F, surv.scale = "percent", pval = T, pval.size = 6, pval.coord = c(300, 0.7))
 ```
 
 ![](man/figures/README-unnamed-chunk-5-1.png)<!-- -->
@@ -115,7 +115,7 @@ jskm(fit, theme = "jama", cumhaz = T, table = T, mark = F, ylab = "Cumulative in
 #### NEJM
 
 ``` r
-jskm(fit, theme = "nejm", nejm.infigure.ratiow = 0.7, nejm.infigure.ratioh = 0.4, nejm.infigure.ylim = c(0, 0.7), cumhaz = T, table = T, mark = F, ylab = "Cumulative incidence (%)", surv.scale = "percent", pval = T, pval.size = 6, pval.coord = c(300, 0.7))
+jskm(fit, theme = "nejm", nejm.infigure.ratiow = 0.7, nejm.infigure.ratioh = 0.4, nejm.infigure.ylim = c(0, 0.7), cumhaz = T, table = T, marks = F, surv.scale = "percent", pval = T, pval.size = 6, pval.coord = c(300, 0.7))
 ```
 
 ![](man/figures/README-unnamed-chunk-6-1.png)<!-- -->
@@ -146,7 +146,7 @@ svyjskm(s2, pval = T, table = T, design = dpbc)
 ![](man/figures/README-unnamed-chunk-7-2.png)<!-- -->
 
 ``` r
-svyjskm(s2, cumhaz = T, ylab = "Cumulative incidence (%)", surv.scale = "percent", pval = T, design = dpbc, pval.coord = c(300, 0.7), showpercent = T)
+svyjskm(s2, cumhaz = T, surv.scale = "percent", pval = T, design = dpbc, pval.coord = c(300, 0.7), showpercent = T)
 ```
 
 ![](man/figures/README-unnamed-chunk-7-3.png)<!-- -->


### PR DESCRIPTION
jskm과 svyjskm 패키지 모두 kaplan-meier곡선이 원점 근처에서 축에 가려져 보이지 않는 문제를 해결했습니다.
scale_y_continuous 함수에서 expand를 수정함으로 해결하였습니다.